### PR TITLE
(feat): variable batch size for dataset iteration

### DIFF
--- a/src/arrayloaders/io/zarr_loader.py
+++ b/src/arrayloaders/io/zarr_loader.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from typing import Self
 
 
-def split_given_size(a, size):
+def split_given_size(a: np.ndarray, size: int) -> list[np.ndarray]:
     return np.split(a, np.arange(size, len(a), size))
 
 OnDiskArray = TypeVar("OnDiskArray", ad.abc.CSRDataset, zarr.Array)

--- a/src/arrayloaders/io/zarr_loader.py
+++ b/src/arrayloaders/io/zarr_loader.py
@@ -366,7 +366,6 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
                         res += [in_memory_indices[s]]
                     yield res
                 if i == (len(splits) - 1): # end of iteration, leftover data needs be kept
-                    print(i, s, in_memory_data.shape)
                     if (s.shape[0] % self._batch_size) != 0:
                         in_memory_data = in_memory_data[s]
                         if in_memory_labels is not None:

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -62,7 +62,7 @@ def open_dense(path: Path):
                     chunk_size=chunk_size,
                     preload_nchunks=preload_nchunks,
                     return_index=True,
-                    batch_size=batch_size
+                    batch_size=batch_size,
                 ).add_anndatas(
                     [
                         (
@@ -89,7 +89,8 @@ def open_dense(path: Path):
                         5,
                         ["label", "label", "label"],
                         dataset_class,
-                        None, 1
+                        None,
+                        1,
                     ],  # list label key
                     [10, 5, None, dataset_class, "data", 1],  # singleton data key
                     [
@@ -97,7 +98,8 @@ def open_dense(path: Path):
                         5,
                         None,
                         dataset_class,
-                        ["data", "data", "data"], 1
+                        ["data", "data", "data"],
+                        1,
                     ],  # list data key
                     [
                         10,
@@ -105,7 +107,7 @@ def open_dense(path: Path):
                         None,
                         dataset_class,
                         None,
-                        5
+                        5,
                     ],  # batch size divides total in memory size evenly
                     [
                         10,
@@ -113,7 +115,7 @@ def open_dense(path: Path):
                         None,
                         dataset_class,
                         None,
-                        50
+                        50,
                     ],  # batch size equal to in-memory size loading
                     [
                         10,
@@ -121,16 +123,14 @@ def open_dense(path: Path):
                         None,
                         dataset_class,
                         None,
-                        15
+                        15,
                     ],  # batch size does not divide in memory size evenly
                 ]
             ]
         ),
     ],
 )
-def test_store_load_dataset(
-    mock_store: Path, *, shuffle: bool, gen_loader
-):
+def test_store_load_dataset(mock_store: Path, *, shuffle: bool, gen_loader):
     """
     This test verifies that the DaskDataset works correctly:
         1. The DaskDataset correctly loads data from the mock store

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -36,7 +36,6 @@ def open_dense(path: Path):
 
 
 @pytest.mark.parametrize("shuffle", [True, False], ids=["shuffled", "unshuffled"])
-@pytest.mark.parametrize("use_dataloader", [True, False], ids=["dataloader", "dataset"])
 @pytest.mark.parametrize(
     "gen_loader",
     [
@@ -57,11 +56,13 @@ def open_dense(path: Path):
                 preload_nchunks=preload_nchunks,
                 dataset_class=dataset_class,
                 obs_keys=obs_keys,
-                layer_keys=layer_keys: dataset_class(
+                layer_keys=layer_keys,
+                batch_size=batch_size: dataset_class(
                     shuffle=shuffle,
                     chunk_size=chunk_size,
                     preload_nchunks=preload_nchunks,
                     return_index=True,
+                    batch_size=batch_size
                 ).add_anndatas(
                     [
                         (
@@ -74,37 +75,61 @@ def open_dense(path: Path):
                     layer_keys,
                     obs_keys,
                 ),
-                id=f"chunk_size={chunk_size}-preload_nchunks={preload_nchunks}-obs_keys={obs_keys}-dataset_class={dataset_class.__name__}-layer_keys={layer_keys}",  # type: ignore[attr-defined]
+                id=f"chunk_size={chunk_size}-preload_nchunks={preload_nchunks}-obs_keys={obs_keys}-dataset_class={dataset_class.__name__}-layer_keys={layer_keys}-batch_size={batch_size}",  # type: ignore[attr-defined]
             )
-            for chunk_size, preload_nchunks, obs_keys, dataset_class, layer_keys in [
+            for chunk_size, preload_nchunks, obs_keys, dataset_class, layer_keys, batch_size in [
                 elem
                 for dataset_class in [ZarrDenseDataset, ZarrSparseDataset]  # type: ignore[list-item]
                 for elem in [
-                    [1, 5, None, dataset_class, None],  # singleton chunk size
-                    [5, 1, None, dataset_class, None],  # singleton preload
-                    [10, 5, "label", dataset_class, None],  # singleton label key
+                    [1, 5, None, dataset_class, None, 1],  # singleton chunk size
+                    [5, 1, None, dataset_class, None, 1],  # singleton preload
+                    [10, 5, "label", dataset_class, None, 1],  # singleton label key
                     [
                         10,
                         5,
                         ["label", "label", "label"],
                         dataset_class,
-                        None,
+                        None, 1
                     ],  # list label key
-                    [10, 5, None, dataset_class, "data"],  # singleton data key
+                    [10, 5, None, dataset_class, "data", 1],  # singleton data key
                     [
                         10,
                         5,
                         None,
                         dataset_class,
-                        ["data", "data", "data"],
+                        ["data", "data", "data"], 1
                     ],  # list data key
+                    [
+                        10,
+                        5,
+                        None,
+                        dataset_class,
+                        None,
+                        5
+                    ],  # batch size divides total in memory size evenly
+                    [
+                        10,
+                        5,
+                        None,
+                        dataset_class,
+                        None,
+                        50
+                    ],  # batch size equal to in-memory size loading
+                    [
+                        10,
+                        5,
+                        None,
+                        dataset_class,
+                        None,
+                        15
+                    ],  # batch size does not divide in memory size evenly
                 ]
             ]
         ),
     ],
 )
 def test_store_load_dataset(
-    mock_store: Path, *, shuffle: bool, gen_loader, use_dataloader: bool
+    mock_store: Path, *, shuffle: bool, gen_loader
 ):
     """
     This test verifies that the DaskDataset works correctly:
@@ -129,9 +154,9 @@ def test_store_load_dataset(
             indices = None
         else:
             x, label, indices = batch
-        n_elems += 1
+        n_elems += 1 if (is_dask := isinstance(loader, DaskDataset)) else x.shape[0]
         # Check feature dimension
-        assert x.shape[0 if is_dense else 1] == 100
+        assert x.shape[0 if is_dask else 1] == 100
         if not shuffle:
             batches += [x]
             if label is not None:
@@ -139,7 +164,7 @@ def test_store_load_dataset(
         if indices is not None:
             assert (
                 (x if is_dense else x.toarray()) == expected_data[indices, ...]
-            ).all()
+            ).all(), n_elems
     # check that we yield all samples from the dataset
     if not shuffle:
         # np.array for sparse
@@ -149,7 +174,7 @@ def test_store_load_dataset(
         np.testing.assert_allclose(stacked, expected_data)
         if len(labels) > 0:
             expected_labels = adata.obs["label"]
-            np.testing.assert_allclose(np.array(labels), expected_labels)
+            np.testing.assert_allclose(np.array(labels).ravel(), expected_labels)
     else:
         assert n_elems == adata.shape[0]
 


### PR DESCRIPTION
A bit messy `iter` but we need to maintain the references over each iteration so encapsulating parts of this in functions is tough, but the logic added to `AnnDataManager.iter` allows the user to specify a `batch_size` which will then yield `batch_size` sized chunks of the data instead of always yielding a single row (the default is still 1).  Why would we want to do this:

1. Making the dataset classes usable outside of the context of a torch data loader (or some other collation thing)
2. Investigating whether or not the torch data loader actually does help when it has workers (i.e., is  the overhead of processes better than just using `zarrs` or `zarr` on its own)
3. Potential speedups for when the data loader actually does help, since indexing in batches is potentially faster than individual rows (although we would need some sort of custom handling re: collation + batch size to make this work)