### PR TITLE
fix: remove shape hotpath

### DIFF
--- a/arrayloaders/io/zarr_loader.py
+++ b/arrayloaders/io/zarr_loader.py
@@ -235,7 +235,7 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
         Returns:
             A :class:`numpy.ndarray` of chunk ids.
         """
-        chunks = np.array(list(range(math.ceil(self.n_obs / chunk_size))))
+        chunks = np.arange(math.ceil(self.n_obs / chunk_size))
         if shuffle:
             worker_handle.shuffle(chunks)
 

--- a/arrayloaders/io/zarr_loader.py
+++ b/arrayloaders/io/zarr_loader.py
@@ -151,7 +151,7 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
             )
         datasets = self.train_datasets + [dataset]
         check_var_shapes(datasets)
-        self._shapes += [dataset.shape]
+        self._shapes = self._shapes + [dataset.shape]
         self.train_datasets = datasets
         if self.labels is not None:  # labels exist
             self.labels += [obs]

--- a/arrayloaders/io/zarr_loader.py
+++ b/arrayloaders/io/zarr_loader.py
@@ -82,6 +82,7 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
     _return_index: bool = False
     _on_add: Callable | None = None
     _batch_size: int = 1
+    _shapes: list[tuple[int, int]] = []
 
     def __init__(
         self,
@@ -100,11 +101,11 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
 
     @property
     def n_obs(self) -> int:
-        return sum(ds.shape[0] for ds in self.train_datasets)
+        return sum(shape[0] for shape in self._shapes)
 
     @property
     def n_var(self) -> int:
-        return self.train_datasets[0].shape[1]
+        return self._shapes[0][1]
 
     def add_anndatas(
         self,
@@ -150,7 +151,7 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
             )
         datasets = self.train_datasets + [dataset]
         check_var_shapes(datasets)
-        self._var_size = datasets[0].shape[1]  # TODO: joins
+        self._shapes += [dataset.shape]
         self.train_datasets = datasets
         if self.labels is not None:  # labels exist
             self.labels += [obs]
@@ -184,9 +185,8 @@ class AnnDataManager(Generic[OnDiskArray, InMemoryArray]):
         max_idx = index.stop
         curr_pos = 0
         slices = []
-        for idx, array in enumerate(self.train_datasets):
+        for idx, (n_obs, _) in enumerate(self._shapes):
             array_start = curr_pos
-            n_obs = array.shape[0]
             array_end = curr_pos + n_obs
 
             start = max(min_idx, array_start)


### PR DESCRIPTION
This `CSRDataset.shape` was coming up as a hotpath for me using unconsolidated metadata (probably because it has to repeatedly open a file to get that information), so should be removed in general.